### PR TITLE
Update render namespace to hyperappRender

### DIFF
--- a/src/browser.d.ts
+++ b/src/browser.d.ts
@@ -1,4 +1,4 @@
-export as namespace render
+export as namespace hyperappRender
 
 import { ActionsType, View } from 'hyperapp'
 import { renderToString } from './index'

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -1,4 +1,4 @@
-export as namespace render
+export as namespace hyperappRender
 
 import { ActionsType, View } from 'hyperapp'
 import { Readable } from 'stream'


### PR DESCRIPTION
This PR change the Typescript `render` namespace in favor of `hyperappRende` following `logger` conventions at hyperapp/logger#18

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
